### PR TITLE
Fix form tab navigation with tabindex="0"

### DIFF
--- a/keycloak-phone-provider.resources/src/main/resources/theme/phone/login/login-reset-password.ftl
+++ b/keycloak-phone-provider.resources/src/main/resources/theme/phone/login/login-reset-password.ftl
@@ -106,7 +106,7 @@
                                            class="${properties.kcInputClass!}" autocomplete="off"/>
                                 </div>
                                 <div class="col-xs-4" style="padding: 0 0 0 5px">
-                                    <input tabindex="2" style="height: 36px"
+                                    <input tabindex="0" style="height: 36px"
                                            class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
                                            type="button" v-model="sendButtonText"
                                            :disabled='sendButtonText !== initSendButtonText'

--- a/keycloak-phone-provider.resources/src/main/resources/theme/phone/login/login-sms-otp-config.ftl
+++ b/keycloak-phone-provider.resources/src/main/resources/theme/phone/login/login-sms-otp-config.ftl
@@ -26,13 +26,13 @@
                          class="${properties.kcLabelClass!}">${msg("phoneNumber")}</label>
                 </div>
                 <div class="col-xs-8" style="padding: 0 5px 0 0">
-                  <input tabindex="1" id="phoneNumber" class="${properties.kcInputClass!}"
+                  <input tabindex="0" id="phoneNumber" class="${properties.kcInputClass!}"
                          name="phoneNumber" type="tel" <#if !phoneNumber??>autofocus</#if>
                          value="${phoneNumber!''}"
                          autocomplete="mobile tel"/>
                 </div>
                 <div class="col-xs-4" style="padding: 0 0 0 5px">
-                  <input tabindex="2" style="height: 36px"
+                  <input tabindex="0" style="height: 36px"
                          class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
                          v-model="sendButtonText" :disabled='sendButtonText !== initSendButtonText'
                          v-on:click="sendVerificationCode()"
@@ -41,14 +41,14 @@
               </div>
               <div class="${properties.kcFormGroupClass!} row">
                 <label for="code" class="${properties.kcLabelClass!}">${msg("verificationCode")}</label>
-                <input tabindex="3" id="code" class="${properties.kcInputClass!}" name="code"
+                <input tabindex="0" id="code" class="${properties.kcInputClass!}" name="code"
                        type="text" <#if phoneNumber??>autofocus</#if>
                        autocomplete="off"/>
               </div>
               <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
                 <input type="hidden" id="id-hidden-input" name="credentialId"
                        <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
-                <input tabindex="4"
+                <input tabindex="0"
                        class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
                        :disabled='sendButtonText === initSendButtonText'
                        name="save" id="kc-login" type="submit" value="${msg("doSubmit")}"/>

--- a/keycloak-phone-provider.resources/src/main/resources/theme/phone/login/login-sms-otp.ftl
+++ b/keycloak-phone-provider.resources/src/main/resources/theme/phone/login/login-sms-otp.ftl
@@ -26,12 +26,12 @@
                                        class="${properties.kcLabelClass!}">${msg("authenticationCode")}</label>
                             </div>
                             <div class="col-xs-8" style="padding: 0 5px 0 0">
-                                <input tabindex="1" id="code" class="${properties.kcInputClass!}" name="code"
+                                <input tabindex="0" id="code" class="${properties.kcInputClass!}" name="code"
                                        type="text" autofocus
                                        autocomplete="off"/>
                             </div>
                             <div class="col-xs-4" style="padding: 0 0 0 5px">
-                                <input tabindex="2" style="height: 36px"
+                                <input tabindex="0" style="height: 36px"
                                        class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
                                        type="button" v-model="sendButtonText"
                                        :disabled='sendButtonText !== initSendButtonText'
@@ -42,7 +42,7 @@
                         <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
                             <input type="hidden" id="id-hidden-input" name="credentialId"
                                    <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
-                            <input tabindex="2"
+                            <input tabindex="0"
                                    class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
                                    name="save" id="kc-login" type="submit" value="${msg("doSubmit")}"/>
                         </div>

--- a/keycloak-phone-provider.resources/src/main/resources/theme/phone/login/login-update-phone-number.ftl
+++ b/keycloak-phone-provider.resources/src/main/resources/theme/phone/login/login-update-phone-number.ftl
@@ -25,13 +25,13 @@
                          class="${properties.kcLabelClass!}">${msg("phoneNumber")}</label>
                 </div>
                 <div class="col-xs-8" style="padding: 0 5px 0 0">
-                  <input tabindex="1" id="phoneNumber" class="${properties.kcInputClass!}"
+                  <input tabindex="0" id="phoneNumber" class="${properties.kcInputClass!}"
                          name="phoneNumber" type="tel" <#if !phoneNumber??>autofocus</#if>
                          value="${phoneNumber!''}"
                          autocomplete="mobile tel"/>
                 </div>
                 <div class="col-xs-4" style="padding: 0 0 0 5px">
-                  <input tabindex="2" style="height: 36px"
+                  <input tabindex="0" style="height: 36px"
                          class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
                          v-model="sendButtonText" :disabled='sendButtonText !== initSendButtonText'
                          v-on:click="sendVerificationCode()"
@@ -40,14 +40,14 @@
               </div>
               <div class="${properties.kcFormGroupClass!} row">
                 <label for="code" class="${properties.kcLabelClass!}">${msg("verificationCode")}</label>
-                <input tabindex="3" id="code" class="${properties.kcInputClass!}" name="code"
+                <input tabindex="0" id="code" class="${properties.kcInputClass!}" name="code"
                        type="text" <#if phoneNumber??>autofocus</#if>
                        autocomplete="off"/>
               </div>
               <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
                 <input type="hidden" id="id-hidden-input" name="credentialId"
                        <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
-                <input tabindex="4"
+                <input tabindex="0"
                        class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
                        name="save" id="kc-login" type="submit" value="${msg("doSubmit")}"/>
               </div>

--- a/keycloak-phone-provider.resources/src/main/resources/theme/phone/login/login.ftl
+++ b/keycloak-phone-provider.resources/src/main/resources/theme/phone/login/login.ftl
@@ -71,7 +71,7 @@
                                         </#if>
                                     </label>
 
-                                    <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}"  type="text" autofocus autocomplete="off"
+                                    <input tabindex="0" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}"  type="text" autofocus autocomplete="off"
                                            aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
                                     />
 
@@ -87,7 +87,7 @@
                             <div class="${properties.kcFormGroupClass!}">
                                 <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
 
-                                <input tabindex="2" id="password" class="${properties.kcInputClass!}" name="password" type="password" autocomplete="off"
+                                <input tabindex="0" id="password" class="${properties.kcInputClass!}" name="password" type="password" autocomplete="off"
                                        aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
                                 />
 
@@ -106,9 +106,9 @@
                                         <div class="checkbox">
                                             <label>
                                                 <#if login.rememberMe??>
-                                                    <input tabindex="3" id="rememberMe" name="rememberMe" type="checkbox" checked> ${msg("rememberMe")}
+                                                    <input tabindex="0" id="rememberMe" name="rememberMe" type="checkbox" checked> ${msg("rememberMe")}
                                                 <#else>
-                                                    <input tabindex="3" id="rememberMe" name="rememberMe" type="checkbox"> ${msg("rememberMe")}
+                                                    <input tabindex="0" id="rememberMe" name="rememberMe" type="checkbox"> ${msg("rememberMe")}
                                                 </#if>
                                             </label>
                                         </div>
@@ -116,7 +116,7 @@
                                 </div>
                                 <div class="${properties.kcFormOptionsWrapperClass!}">
                                     <#if realm.resetPasswordAllowed>
-                                        <span><a tabindex="5" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
+                                        <span><a tabindex="0" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
                                     </#if>
                                 </div>
                             </div>
@@ -128,7 +128,7 @@
                             <div v-if="phoneActivated">
                                 <div class="${properties.kcFormGroupClass!}">
                                     <label for="phoneNumber" class="${properties.kcLabelClass!}">${msg("phoneNumber")}</label>
-                                    <input tabindex="1" type="text" id="phoneNumber" name="phoneNumber" v-model="phoneNumber"
+                                    <input tabindex="0" type="text" id="phoneNumber" name="phoneNumber" v-model="phoneNumber"
                                            aria-invalid="<#if messagesPerField.existsError('code','phoneNumber')>true</#if>"
                                            class="${properties.kcInputClass!}" autofocus/>
                                     <#if messagesPerField.existsError('code','phoneNumber')>
@@ -143,13 +143,13 @@
                                         <label for="code" class="${properties.kcLabelClass!}">${msg("verificationCode")}</label>
                                     </div>
                                     <div class="col-xs-8" style="padding: 0 5px 0 0">
-                                        <input tabindex="2" type="text" id="code" name="code"
+                                        <input tabindex="0" type="text" id="code" name="code"
                                                aria-invalid="<#if messagesPerField.existsError('code','phoneNumber')>true</#if>"
                                                class="${properties.kcInputClass!}" autocomplete="off"/>
 
                                     </div>
                                     <div class="col-xs-4" style="padding: 0 0 0 5px">
-                                        <input tabindex="2" style="height: 36px"
+                                        <input tabindex="0" style="height: 36px"
                                                class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
                                                type="button" v-model="sendButtonText" :disabled='sendButtonText !== initSendButtonText' v-on:click="sendVerificationCode()"/>
                                     </div>
@@ -160,7 +160,7 @@
 
                         <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
                             <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
-                            <input tabindex="4" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
+                            <input tabindex="0" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
                         </div>
 
                     </form>
@@ -222,7 +222,7 @@
         <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
             <div id="kc-registration-container">
                 <div id="kc-registration">
-                    <span>${msg("noAccount")} <a tabindex="6"
+                    <span>${msg("noAccount")} <a tabindex="0"
                                                  href="${url.registrationUrl}">${msg("doRegister")}</a></span>
                 </div>
             </div>

--- a/keycloak-phone-provider.resources/src/main/resources/theme/phone/login/register.ftl
+++ b/keycloak-phone-provider.resources/src/main/resources/theme/phone/login/register.ftl
@@ -142,7 +142,7 @@
                         <label for="phoneNumber" class="${properties.kcLabelClass!}">${msg("phoneNumber")}</label>
                     </div>
                     <div class="${properties.kcInputWrapperClass!}">
-                        <input tabindex="1" id="phoneNumber" class="${properties.kcInputClass!}"
+                        <input tabindex="0" id="phoneNumber" class="${properties.kcInputClass!}"
                                name="phoneNumber" id="phoneNumber" type="tel"
                                aria-invalid="<#if messagesPerField.existsError('phoneNumber')>true</#if>"
                                autofocus
@@ -164,7 +164,7 @@
                         <label for="registerCode" class="${properties.kcLabelClass!}">${msg("verificationCode")}</label>
                     </div>
                     <div class="col-xs-8" style="padding: 0 5px 0 0">
-                        <input tabindex="3" id="code" name="code"
+                        <input tabindex="0" id="code" name="code"
                                aria-invalid="<#if messagesPerField.existsError('registerCode')>true</#if>"
                                type="text" class="${properties.kcInputClass!}"
                                autocomplete="off"/>
@@ -175,7 +175,7 @@
                         </#if>
                     </div>
                     <div class="col-xs-4" style="padding: 0 0 0 5px">
-                        <input tabindex="2" style="height: 36px"
+                        <input tabindex="0" style="height: 36px"
                                class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
                                v-model="sendButtonText" :disabled='sendButtonText !== initSendButtonText'
                                v-on:click="sendVerificationCode()"

--- a/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/authentication/forms/RegistrationPhoneVerificationCode.java
+++ b/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/authentication/forms/RegistrationPhoneVerificationCode.java
@@ -80,8 +80,8 @@ public class RegistrationPhoneVerificationCode implements FormAction, FormAction
         .property().name(CONFIG_OPT_CREDENTIAL)
         .type(BOOLEAN_TYPE)
         .defaultValue(false)
-        .label("Create a phone OPT credential")
-        .helpText("Create a phone OPT credential.")
+        .label("Create a phone OTP credential")
+        .helpText("Create a phone OTP credential.")
         .add()
         .build();
   }


### PR DESCRIPTION
This changeset fixes tabindex navigation by using the recommended `tabindex="0"` value everywhere.
See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex

With this change, navigating through the added form elements  using the <kbd>tab</kbd> key works sequentially, as one would wish.

Testing in chrome before:
![before](https://user-images.githubusercontent.com/4186004/224566240-aed14b9c-18d1-4243-9858-c138f1d532b1.gif)

After:

![after](https://user-images.githubusercontent.com/4186004/224566247-9f94d3b8-5e62-4ea4-9491-c4cca70f1747.gif)

