### PR TITLE
fix: Replace StringBuilder by StringBuffer to make it compatible with keycloak 20.0.5

### DIFF
--- a/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/authentication/authenticators/browser/SmsOtpMfaAuthenticator.java
+++ b/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/authentication/authenticators/browser/SmsOtpMfaAuthenticator.java
@@ -79,7 +79,7 @@ public class SmsOtpMfaAuthenticator implements Authenticator, CredentialValidato
 
   public void addCookie(AuthenticationFlowContext context, String name, String value, String path, String domain, String comment, int maxAge, boolean secure, boolean httpOnly) {
     HttpResponse response = context.getSession().getContext().getContextObject(HttpResponse.class);
-    StringBuilder cookieBuf = new StringBuilder();
+    StringBuffer cookieBuf = new StringBuffer();
     ServerCookie.appendCookieValue(cookieBuf, 1, name, value, path, domain, comment, maxAge, secure, httpOnly, null);
     String cookie = cookieBuf.toString();
     response.getOutputHeaders().add(HttpHeaders.SET_COOKIE, cookie);


### PR DESCRIPTION
Hello,

Thank you for this project. I am currently running `20.0.5` version of keycloak in production and I cannot upgrade to 21 so far because of https://github.com/klausbetz/apple-identity-provider-keycloak/issues/13.

So, I tried to add your jar into `/opt/keycloak/providers` but I had an issue because keycloak 21 is running on java 19 and keycloak 20 on java 11. The `./kc.sh build` failed (You are providing .jar only for 21 version of keycloak -> java 19)

Here is the issue:
```
ERROR: cc/coopersoft/keycloak/phone/providers/spi/PhoneVerificationCodeSpi has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```

**Then**, This PR is to fix build in java 11. I just replaced a `StringBuilder` by a `StringBuffer`

It should be awesome to have releases for `20.0.X` versions of keycloak as well. I can help for this as I am already compiling it for `20.0.5` and it worked perfectly.

Here is the `properties` section of `pom.xml` to compile it with `20.0.5` version of keycloak
```
<properties>
    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
    <maven.compiler.source>11</maven.compiler.source>
    <maven.compiler.target>11</maven.compiler.target>
    <java.version>11</java.version>
    <version.keycloak>20.0.5</version.keycloak>
</properties>
```

Cheers
