### PR TITLE
Canonicalize phone numbers using Google's libphonenumbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ If you want to build the project, simply run  `examples/docker-build.sh` after c
     --spi-phone-default-hour-maximum=3 # How many send sms count in one hour.
     --spi-phone-default-[$realm-]duplicate-phone=false # allow one phone register multi user
     --spi-phone-default-[$realm-]number-regx=^\+?\d+$
+    --spi-phone-canonicalize-phone-numbers=true # whether to parse user-supplied phone numbers and put into canonical International E.163 format.  _Required for proper duplicate phone number detection_
+    --spi-phone-default-phone-region=US # a default region to be used when parsing user-supplied phone numbers. Lookup codes at https://www.unicode.org/cldr/cldr-aux/charts/30/supplemental/territory_information.html
+
 
     ...  # provider param refer provider`s readme.md
 ```

--- a/jboss-cli/module-add.cli
+++ b/jboss-cli/module-add.cli
@@ -2,7 +2,8 @@
 
 
 # main provider
-module add --name=keycloak-phone-provider --resources=keycloak-phone-provider.jar --dependencies=org.keycloak.keycloak-core,org.keycloak.keycloak-common,org.hibernate,org.keycloak.keycloak-server-spi,org.keycloak.keycloak-server-spi-private,org.keycloak.keycloak-services,org.keycloak.keycloak-model-jpa,org.jboss.logging,javax.api,javax.ws.rs.api,javax.transaction.api,javax.persistence.api,org.jboss.resteasy.resteasy-jaxrs,org.apache.httpcomponents,org.apache.commons.lang,javax.xml.bind.api,com.squareup.okhttp3
+module add --name=com.googlecode.libphonenumber --resources=libphonenumber-8.13.7.jar
+module add --name=keycloak-phone-provider --resources=keycloak-phone-provider.jar --dependencies=org.keycloak.keycloak-core,org.keycloak.keycloak-common,org.hibernate,org.keycloak.keycloak-server-spi,org.keycloak.keycloak-server-spi-private,org.keycloak.keycloak-services,org.keycloak.keycloak-model-jpa,org.jboss.logging,javax.api,javax.ws.rs.api,javax.transaction.api,javax.persistence.api,org.jboss.resteasy.resteasy-jaxrs,org.apache.httpcomponents,org.apache.commons.lang,javax.xml.bind.api,com.squareup.okhttp3,com.googlecode.libphonenumber
 
 # dummy provider
 module add --name=keycloak-sms-provider-dummy --resources=keycloak-sms-provider-dummy.jar --dependencies=org.keycloak.keycloak-core,org.keycloak.keycloak-server-spi,org.jboss.logging,keycloak-phone-provider

--- a/keycloak-phone-provider.resources/src/main/resources/theme/phone/login/messages/messages_en.properties
+++ b/keycloak-phone-provider.resources/src/main/resources/theme/phone/login/messages/messages_en.properties
@@ -15,7 +15,7 @@ authenticationCodeDoesNotMatch=Informed authentication code does not match ours.
 abusedMessageService=Too many code requests for your mobile number.
 sendVerificationCodeFail=Verification code send fail!
 
-phoneNumberExists=Phone number is Exists
+phoneNumberExists=Phone number already registered
 requiredVerificationCode=Verification code is required.
 phoneInstruction=Use phone verification code reset password.
 phoneUserNotFound=User not exists.

--- a/keycloak-phone-provider/pom.xml
+++ b/keycloak-phone-provider/pom.xml
@@ -19,6 +19,11 @@
             <version>${version.keycloak}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+          <groupId>com.googlecode.libphonenumber</groupId>
+          <artifactId>libphonenumber</artifactId>
+          <version>8.13.7</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/Utils.java
+++ b/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/Utils.java
@@ -6,6 +6,10 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
 
+import com.google.i18n.phonenumbers.*;
+import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberFormat;
+
+
 import java.util.Comparator;
 import java.util.Optional;
 
@@ -45,6 +49,18 @@ public class Utils {
 
     public static Optional<String> getPhoneNumberRegx(KeycloakSession session){
         return session.getProvider(PhoneProvider.class).phoneNumberRegx(session.getContext().getRealm().getName());
+    }
+
+    /**
+    * Parses a phone number with google's libphonenumber and then outputs it's
+    * international canonical form
+    *
+    */
+    public static String canonicalizePhoneNumber(KeycloakSession session, String phoneNumber, Optional<String> defaultRegion) throws NumberParseException {
+        var phoneNumberUtil = PhoneNumberUtil.getInstance();
+
+        var parsedNumber = phoneNumberUtil.parse(phoneNumber, defaultRegion.isPresent() ? defaultRegion.get() : null);
+        return phoneNumberUtil.format(parsedNumber,  PhoneNumberFormat.INTERNATIONAL);
     }
 
 }

--- a/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/authentication/authenticators/browser/PhoneUsernamePasswordForm.java
+++ b/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/authentication/authenticators/browser/PhoneUsernamePasswordForm.java
@@ -3,6 +3,7 @@ package cc.coopersoft.keycloak.phone.authentication.authenticators.browser;
 import cc.coopersoft.keycloak.phone.authentication.forms.SupportPhonePages;
 import cc.coopersoft.keycloak.phone.providers.constants.TokenCodeType;
 import cc.coopersoft.keycloak.phone.providers.spi.PhoneVerificationCodeProvider;
+import cc.coopersoft.keycloak.phone.providers.spi.PhoneProvider;
 import cc.coopersoft.common.OptionalStringUtils;
 import cc.coopersoft.keycloak.phone.Utils;
 import org.apache.commons.lang.StringUtils;
@@ -93,6 +94,8 @@ public class PhoneUsernamePasswordForm extends UsernamePasswordForm implements A
       context.forceChallenge(challengeResponse);
       return false;
     }
+    var phoneProvider = context.getSession().getProvider(PhoneProvider.class);
+    phoneNumber = phoneProvider.canonicalizePhoneNumber(phoneNumber);
     phoneNumber = phoneNumber.trim();
 
     String code = inputData.getFirst(FIELD_VERIFICATION_CODE);

--- a/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/authentication/authenticators/resetcred/ResetCredentialWithPhone.java
+++ b/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/authentication/authenticators/resetcred/ResetCredentialWithPhone.java
@@ -5,6 +5,7 @@ import cc.coopersoft.common.OptionalStringUtils;
 import cc.coopersoft.keycloak.phone.Utils;
 import cc.coopersoft.keycloak.phone.providers.constants.TokenCodeType;
 import cc.coopersoft.keycloak.phone.providers.spi.PhoneVerificationCodeProvider;
+import cc.coopersoft.keycloak.phone.providers.spi.PhoneProvider;
 import org.apache.commons.lang.StringUtils;
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
@@ -115,6 +116,8 @@ public class ResetCredentialWithPhone implements Authenticator, AuthenticatorFac
       }
 
       phoneNumber = phoneNumber.trim();
+      var phoneProvider = context.getSession().getProvider(PhoneProvider.class);
+      phoneNumber = phoneProvider.canonicalizePhoneNumber(phoneNumber);
       String verificationCode = inputData.getFirst(FIELD_VERIFICATION_CODE);
       if (StringUtils.isBlank(verificationCode)) {
         invalidVerificationCode(context, phoneNumber);

--- a/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/authentication/requiredactions/ConfigSmsOtpRequiredAction.java
+++ b/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/authentication/requiredactions/ConfigSmsOtpRequiredAction.java
@@ -4,6 +4,7 @@ import cc.coopersoft.keycloak.phone.credential.PhoneOtpCredentialModel;
 import cc.coopersoft.keycloak.phone.credential.PhoneOtpCredentialProvider;
 import cc.coopersoft.keycloak.phone.credential.PhoneOtpCredentialProviderFactory;
 import cc.coopersoft.keycloak.phone.providers.spi.PhoneVerificationCodeProvider;
+import cc.coopersoft.keycloak.phone.providers.spi.PhoneProvider;
 import org.keycloak.authentication.RequiredActionContext;
 import org.keycloak.authentication.RequiredActionProvider;
 import org.keycloak.credential.CredentialProvider;
@@ -30,8 +31,11 @@ public class ConfigSmsOtpRequiredAction implements RequiredActionProvider {
 
     @Override
     public void processAction(RequiredActionContext context) {
-        PhoneVerificationCodeProvider phoneVerificationCodeProvider = context.getSession().getProvider(PhoneVerificationCodeProvider.class);
+        var session = context.getSession();
+        PhoneVerificationCodeProvider phoneVerificationCodeProvider = session.getProvider(PhoneVerificationCodeProvider.class);
         String phoneNumber = context.getHttpRequest().getDecodedFormParameters().getFirst("phoneNumber");
+        var phoneProvider = session.getProvider(PhoneProvider.class);
+        phoneNumber = phoneProvider.canonicalizePhoneNumber(phoneNumber);
         String code = context.getHttpRequest().getDecodedFormParameters().getFirst("code");
         try {
             phoneVerificationCodeProvider.validateCode(context.getUser(), phoneNumber, code);

--- a/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/authentication/requiredactions/UpdatePhoneNumberRequiredAction.java
+++ b/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/authentication/requiredactions/UpdatePhoneNumberRequiredAction.java
@@ -2,6 +2,7 @@ package cc.coopersoft.keycloak.phone.authentication.requiredactions;
 
 import cc.coopersoft.keycloak.phone.authentication.forms.SupportPhonePages;
 import cc.coopersoft.keycloak.phone.providers.spi.PhoneVerificationCodeProvider;
+import cc.coopersoft.keycloak.phone.providers.spi.PhoneProvider;
 import org.keycloak.authentication.RequiredActionContext;
 import org.keycloak.authentication.RequiredActionProvider;
 
@@ -28,6 +29,8 @@ public class UpdatePhoneNumberRequiredAction implements RequiredActionProvider {
     public void processAction(RequiredActionContext context) {
         PhoneVerificationCodeProvider phoneVerificationCodeProvider = context.getSession().getProvider(PhoneVerificationCodeProvider.class);
         String phoneNumber = context.getHttpRequest().getDecodedFormParameters().getFirst(SupportPhonePages.FIELD_PHONE_NUMBER);
+        var phoneProvider = context.getSession().getProvider(PhoneProvider.class);
+        phoneNumber = phoneProvider.canonicalizePhoneNumber(phoneNumber);
         String code = context.getHttpRequest().getDecodedFormParameters().getFirst(SupportPhonePages.FIELD_VERIFICATION_CODE);
         try {
             phoneVerificationCodeProvider.validateCode(context.getUser(), phoneNumber, code);

--- a/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/providers/spi/PhoneProvider.java
+++ b/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/providers/spi/PhoneProvider.java
@@ -16,4 +16,9 @@ public interface PhoneProvider extends Provider {
     Optional<String> phoneNumberRegx(String realm);
 
     int sendTokenCode(String phoneNumber, TokenCodeType type, String kind);
+
+    String canonicalizePhoneNumber(String phoneNumber);
+
+    Optional<String> defaultPhoneRegion();
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
             <version>${version.keycloak}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+          <groupId>com.googlecode.libphonenumber</groupId>
+          <artifactId>libphonenumber</artifactId>
+          <version>8.13.7</version>
+        </dependency>
     </dependencies>
 
 


### PR DESCRIPTION
With runtime switch of `--spi-phone-canonicalize-phone-numbers=true`, parse all user-supplied phone numbers and transform the numbers into a standard form so that phone numbers will not be duplicated, unless specified with `--spi-phone-default-duplicate-phone=true`