### PR TITLE
fix BY_WHOM column width for federated users

### DIFF
--- a/keycloak-phone-provider/src/main/resources/META-INF/changelog/token-code-changelog.xml
+++ b/keycloak-phone-provider/src/main/resources/META-INF/changelog/token-code-changelog.xml
@@ -43,4 +43,11 @@
     </createIndex>
 
   </changeSet>
+  
+  <changeSet author="cooper" id="token-code-6.2">
+    <modifyDataType
+      columnName="BY_WHOM"
+      newDataType="VARCHAR(80)"
+      tableName="PHONE_MESSAGE_TOKEN_CODE"/>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Increases BY_WHOM column width from 36 to 80 characters. Federated users use more characters than 36 (length of a uuid).

Fixes #58 