### PR TITLE
cicd: add workflow to publish packages into github workspace automatically

### DIFF
--- a/.github/workflows/mavenpublish.yml
+++ b/.github/workflows/mavenpublish.yml
@@ -1,0 +1,32 @@
+name: Maven Package
+
+on:
+  release:
+    types: [released]
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 18
+      uses: actions/setup-java@v1
+      with:
+        java-version: 18
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Test
+      run: mvn clean test
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Publish to GitHub Packages Apache Maven
+      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,15 @@
         <version.keycloak>21.0.2</version.keycloak>
     </properties>
 
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub OWNER Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/cooperlyt/keycloak-phone-provider</url>
+        </repository>
+    </distributionManagement>
+
     <modules>
         <module>keycloak-phone-provider</module>
         <module>keycloak-phone-provider.resources</module>


### PR DESCRIPTION
Would it be nice to automatically publish the packages into GitHub workspace so users can download them easily?  😸 

![image](https://github.com/cooperlyt/keycloak-phone-provider/assets/3367820/7496f0ed-afa5-487e-9d63-ff9855717dce)
