### PR TITLE
increase max length of ip field to support ipv6 addresses

### DIFF
--- a/keycloak-phone-provider/src/main/resources/META-INF/changelog/token-code-changelog.xml
+++ b/keycloak-phone-provider/src/main/resources/META-INF/changelog/token-code-changelog.xml
@@ -50,4 +50,10 @@
       newDataType="VARCHAR(80)"
       tableName="PHONE_MESSAGE_TOKEN_CODE"/>
   </changeSet>
+  <changeSet author="cooper" id="token-code-6.3">
+    <modifyDataType
+      columnName="IP"
+      newDataType="VARCHAR(255)"
+      tableName="PHONE_MESSAGE_TOKEN_CODE"/>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
If the server and clients supports booth are using IPv6 to request a sms code, the request will fail with a database error. 

Currently the Colum  "IP" is limited to a length of 21. This is not sufficient for IPv6 addresses